### PR TITLE
Hash - changed to chunk size instead of reading entire file

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
@@ -876,11 +876,12 @@ class RNFetchBlobFS {
             MessageDigest md = MessageDigest.getInstance(algorithms.get(algorithm));
 
             FileInputStream inputStream = new FileInputStream(path);
-            byte[] buffer = new byte[(int)file.length()];
+            int chunkSize = 4096 * 256; // 1Mb
+            byte[] buffer = new byte[chunkSize];
 
-            int read;
-            while ((read = inputStream.read(buffer)) != -1) {
-                md.update(buffer, 0, read);
+            int bytesRead;
+            while ((bytesRead = inputStream.read(buffer)) != -1) {
+                md.update(buffer, 0, bytesRead);
             }
 
             StringBuilder hexString = new StringBuilder();


### PR DESCRIPTION
When trying to hash large files, it is easy to get an out of memory exception. This is because the buffer is being allocated the full size of the file, when it should be chunked.